### PR TITLE
feat: add Google AI file upload service

### DIFF
--- a/dotnet/src/Connectors/Connectors.Google.UnitTests/Services/GoogleAIFileServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.Google.UnitTests/Services/GoogleAIFileServiceTests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel.Connectors.Google;
+using Xunit;
+
+namespace SemanticKernel.Connectors.Google.UnitTests.Services;
+
+public sealed class GoogleAIFileServiceTests : IDisposable
+{
+    private const string ApiKey = "test-key";
+    private readonly HttpClient _httpClient;
+    private readonly HttpMessageHandlerStub _messageHandlerStub;
+
+    public GoogleAIFileServiceTests()
+    {
+        this._messageHandlerStub = new HttpMessageHandlerStub
+        {
+            ResponseToReturn = new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"name\":\"files/123\",\"displayName\":\"file.txt\",\"mimeType\":\"text/plain\",\"sizeBytes\":\"4\"}", Encoding.UTF8, "application/json")
+            }
+        };
+        this._httpClient = new HttpClient(this._messageHandlerStub, disposeHandler: false);
+    }
+
+    [Fact]
+    public async Task UploadSendsMultipartRequestAsync()
+    {
+        // Arrange
+        var service = new GoogleAIFileService(ApiKey, httpClient: this._httpClient);
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes("test"));
+
+        // Act
+        var file = await service.UploadFileAsync("file.txt", "text/plain", stream);
+
+        // Assert
+        Assert.Equal(HttpMethod.Post, this._messageHandlerStub.Method);
+        Assert.NotNull(this._messageHandlerStub.RequestUri);
+        Assert.Contains("upload", this._messageHandlerStub.RequestUri.ToString(), StringComparison.Ordinal);
+        Assert.True(this._messageHandlerStub.RequestHeaders!.Contains("x-goog-api-key"));
+        Assert.Equal("multipart/form-data", this._messageHandlerStub.ContentHeaders!.ContentType!.MediaType);
+        Assert.Contains("file.txt", Encoding.UTF8.GetString(this._messageHandlerStub.FirstMultipartContent!));
+        Assert.Equal("files/123", file.Name);
+    }
+
+    public void Dispose()
+    {
+        this._httpClient.Dispose();
+        this._messageHandlerStub.Dispose();
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Google/Core/Gemini/Clients/GoogleAIFileClient.cs
+++ b/dotnet/src/Connectors/Connectors.Google/Core/Gemini/Clients/GoogleAIFileClient.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.SemanticKernel.Connectors.Google.Core;
+
+/// <summary>
+/// Client for Google Gemini file upload operations.
+/// </summary>
+internal sealed class GoogleAIFileClient : ClientBase
+{
+    private readonly Uri _fileUploadEndpoint;
+
+    /// <summary>
+    /// Initializes a new instance for GoogleAI.
+    /// </summary>
+    /// <param name="httpClient">HTTP client.</param>
+    /// <param name="apiKey">GoogleAI API key.</param>
+    /// <param name="apiVersion">Version of the Google API.</param>
+    /// <param name="logger">Logger.</param>
+    public GoogleAIFileClient(HttpClient httpClient, string apiKey, GoogleAIVersion apiVersion, ILogger? logger = null)
+        : base(httpClient: httpClient, logger: logger, apiKey: apiKey)
+    {
+        Verify.NotNullOrWhiteSpace(apiKey);
+        string versionSubLink = GetApiVersionSubLink(apiVersion);
+        this._fileUploadEndpoint = new Uri($"https://generativelanguage.googleapis.com/upload/{versionSubLink}/files?uploadType=multipart");
+    }
+
+    /// <summary>
+    /// Uploads a file to the Gemini API.
+    /// </summary>
+    /// <param name="fileName">Name of the file.</param>
+    /// <param name="mimeType">Mime type of the file.</param>
+    /// <param name="content">Stream with file content.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public async Task<GoogleAIFile> UploadFileAsync(string fileName, string mimeType, Stream content, CancellationToken cancellationToken = default)
+    {
+        Verify.NotNullOrWhiteSpace(fileName);
+        Verify.NotNullOrWhiteSpace(mimeType);
+        Verify.NotNull(content);
+
+        using var request = await this.CreateHttpRequestAsync(null!, this._fileUploadEndpoint).ConfigureAwait(false);
+
+        var metadata = new
+        {
+            file = new { displayName = fileName, mimeType }
+        };
+
+        using var metadataContent = new StringContent(JsonSerializer.Serialize(metadata), Encoding.UTF8, "application/json");
+        using var fileContent = new StreamContent(content);
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue(mimeType);
+
+        var multipartContent = new MultipartFormDataContent
+        {
+            { metadataContent, "metadata" },
+            { fileContent, "file", fileName }
+        };
+
+        request.Content = multipartContent;
+
+        string body = await this.SendRequestAndGetStringBodyAsync(request, cancellationToken).ConfigureAwait(false);
+        return DeserializeResponse<GoogleAIFile>(body);
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Google/Core/Gemini/Models/GoogleAIFile.cs
+++ b/dotnet/src/Connectors/Connectors.Google/Core/Gemini/Models/GoogleAIFile.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.SemanticKernel.Connectors.Google;
+
+/// <summary>
+/// Represents a file reference returned by Gemini services.
+/// </summary>
+public sealed class GoogleAIFile
+{
+    /// <summary>
+    /// Identifier of the uploaded file.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Display name of the file.
+    /// </summary>
+    [JsonPropertyName("displayName")]
+    public string? DisplayName { get; set; }
+
+    /// <summary>
+    /// File mime type.
+    /// </summary>
+    [JsonPropertyName("mimeType")]
+    public string? MimeType { get; set; }
+
+    /// <summary>
+    /// Size of the file in bytes.
+    /// </summary>
+    [JsonPropertyName("sizeBytes")]
+    [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]
+    public long SizeBytes { get; set; }
+}

--- a/dotnet/src/Connectors/Connectors.Google/Services/GoogleAIFileService.cs
+++ b/dotnet/src/Connectors/Connectors.Google/Services/GoogleAIFileService.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Connectors.Google.Core;
+using Microsoft.SemanticKernel.Http;
+
+namespace Microsoft.SemanticKernel.Connectors.Google;
+
+/// <summary>
+/// Service for uploading files to Google AI Gemini endpoints.
+/// </summary>
+public sealed class GoogleAIFileService
+{
+    private readonly GoogleAIFileClient _client;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GoogleAIFileService"/> class.
+    /// </summary>
+    /// <param name="apiKey">API key used for authentication.</param>
+    /// <param name="apiVersion">Version of Google AI API.</param>
+    /// <param name="httpClient">Optional HTTP client instance.</param>
+    /// <param name="loggerFactory">Logger factory.</param>
+    public GoogleAIFileService(string apiKey, GoogleAIVersion apiVersion = GoogleAIVersion.V1_Beta, HttpClient? httpClient = null, ILoggerFactory? loggerFactory = null)
+    {
+        Verify.NotNullOrWhiteSpace(apiKey);
+        this._client = new GoogleAIFileClient(
+            httpClient: HttpClientProvider.GetHttpClient(httpClient),
+            apiKey: apiKey,
+            apiVersion: apiVersion,
+            logger: loggerFactory?.CreateLogger(typeof(GoogleAIFileService)));
+    }
+
+    /// <summary>
+    /// Uploads a file to Gemini service.
+    /// </summary>
+    /// <param name="fileName">Name of file.</param>
+    /// <param name="mimeType">Mime type.</param>
+    /// <param name="content">Stream content.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public Task<GoogleAIFile> UploadFileAsync(string fileName, string mimeType, Stream content, CancellationToken cancellationToken = default)
+        => this._client.UploadFileAsync(fileName, mimeType, content, cancellationToken);
+}


### PR DESCRIPTION
## Summary
- support uploading files to Google Gemini API
- expose GoogleAIFileService and related models
- test GoogleAI file uploads with multipart requests

## Testing
- `dotnet format dotnet/src/Connectors/Connectors.Google/Connectors.Google.csproj` *(fails: Unable to fix CA2000. No associated code fix found.)*
- `dotnet test dotnet/src/Connectors/Connectors.Google.UnitTests/Connectors.Google.UnitTests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6899416c521c8322a889fd750c16fb58